### PR TITLE
Extra spec for completing orders that are already paid

### DIFF
--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -613,6 +613,16 @@ describe Spree::Order, :type => :model do
         expect(Spree::InventoryUnit.where(shipment_id: shipment.id).count).to eq(0)
       end
     end
+
+    context 'the order is already paid' do
+      let(:order) { create(:order_with_line_items) }
+
+      it 'can complete the order' do
+        payment = create(:payment, state: 'completed', order: order, amount: order.total)
+        order.update!
+        expect(order.complete).to eq(true)
+      end
+    end
   end
 
   context "subclassed order" do


### PR DESCRIPTION
Seems like it would be nice to have a spec at this level as well.
This fails when the fix to Order#process_payments_with is absent.
