### PR TITLE
Initialize Stock Package and Packer with Order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Solidus 2.4.0 (master, unreleased)
 
+- Replace order foreign key from `Spree::InventoryUnit` with a delegate to the inventory unit's `Spree::Shipment`. `Spree::Stock::Package` and `Spree::Stock::Packer` now have to be initialized with a mandatory order argument. [\#2125](https://github.com/solidusio/solidus/pull/2125) ([jhawthorn](https://github.com/jhawthorn), [mamhoff](https://github.com/mamhoff))
+
 - Change HTTP Status code for `Api::ShipmentsController#transfer_to_*` to be always 202 Accepted rather than 201 Created or 500.
   Speed up changing fulfilment for parts of a shipment [\#2070](https://github.com/solidusio/solidus/pull/2070) ([mamhoff](https://github.com/mamhoff))
 

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -261,7 +261,7 @@ module Spree
     end
 
     def to_package
-      package = Stock::Package.new(stock_location)
+      package = Stock::Package.new(order, stock_location)
       package.shipment = self
       inventory_units.includes(:variant).joins(:variant).group_by(&:state).each do |state, state_inventory_units|
         package.add_multiple state_inventory_units, state.to_sym

--- a/core/app/models/spree/stock/coordinator.rb
+++ b/core/app/models/spree/stock/coordinator.rb
@@ -138,7 +138,7 @@ module Spree
       end
 
       def build_packer(stock_location, inventory_units)
-        Packer.new(stock_location, inventory_units, splitters(stock_location))
+        Packer.new(order, stock_location, inventory_units, splitters(stock_location))
       end
 
       def splitters(_stock_location)

--- a/core/app/models/spree/stock/package.rb
+++ b/core/app/models/spree/stock/package.rb
@@ -1,12 +1,14 @@
 module Spree
   module Stock
     class Package
-      attr_reader :stock_location, :contents
+      attr_reader :order, :stock_location, :contents
       attr_accessor :shipment
 
-      # @param stock_location [Spree::StockLocation] the stock location this package originates from
+      # @param order [Spree::Order] the order this package originates from
+      # @param stock_location [Spree::StockLocation] the stock location this package will be sent from
       # @param contents [Array<Spree::Stock::ContentItem>] the contents of this package
-      def initialize(stock_location, contents = [])
+      def initialize(order, stock_location, contents = [])
+        @order = order
         @stock_location = stock_location
         @contents = contents
       end
@@ -38,13 +40,6 @@ module Spree
       def remove(inventory_unit)
         item = find_item(inventory_unit)
         @contents -= [item] if item
-      end
-
-      # @return [Spree::Order] the order associated with this package
-      def order
-        # Fix regression that removed package.order.
-        # Find it dynamically through an inventory_unit.
-        contents.detect { |item| !!item.try(:line_item).try(:order) }.try(:line_item).try(:order)
       end
 
       # @return [Float] the summed weight of the contents of this package

--- a/core/app/models/spree/stock/packer.rb
+++ b/core/app/models/spree/stock/packer.rb
@@ -1,9 +1,15 @@
 module Spree
   module Stock
     class Packer
-      attr_reader :stock_location, :inventory_units, :splitters
+      attr_reader :order, :stock_location, :inventory_units, :splitters
 
-      def initialize(stock_location, inventory_units, splitters = [Splitter::Base])
+      # @param order [Spree::Order] the order the inventory units originate from
+      # @param stock_location [Spree::StockLocation] the stock location the inventory units will be sent from
+      # @param inventory_units [Array<Spree::Stock::ContentItem>] the inventory units to be packed
+      # @param splitters [Array<Spree::Stock::Splitter::Base>] the splitter classes that will be used
+      #        to split the initial default package
+      def initialize(order, stock_location, inventory_units, splitters = [Splitter::Base])
+        @order = order
         @stock_location = stock_location
         @inventory_units = inventory_units
         @splitters = splitters
@@ -18,7 +24,7 @@ module Spree
       end
 
       def default_package
-        package = Package.new(stock_location)
+        package = Package.new(order, stock_location)
         inventory_units.group_by(&:variant).each do |variant, variant_inventory_units|
           units = variant_inventory_units.clone
           if variant.should_track_inventory?

--- a/core/app/models/spree/stock/splitter/base.rb
+++ b/core/app/models/spree/stock/splitter/base.rb
@@ -8,7 +8,7 @@ module Spree
           @packer = packer
           @next_splitter = next_splitter
         end
-        delegate :stock_location, to: :packer
+        delegate :order, :stock_location, to: :packer
 
         def split(packages)
           return_next(packages)
@@ -21,7 +21,7 @@ module Spree
         end
 
         def build_package(contents = [])
-          Spree::Stock::Package.new(stock_location, contents)
+          Spree::Stock::Package.new(order, stock_location, contents)
         end
       end
     end

--- a/core/lib/spree/testing_support/factories/stock_package_factory.rb
+++ b/core/lib/spree/testing_support/factories/stock_package_factory.rb
@@ -1,17 +1,19 @@
 require 'spree/testing_support/factories/inventory_unit_factory'
 require 'spree/testing_support/factories/variant_factory'
+require 'spree/testing_support/factories/order_factory'
 
 FactoryGirl.define do
   factory :stock_package, class: Spree::Stock::Package do
     skip_create
 
     transient do
+      order { build(:order) }
       stock_location { build(:stock_location) }
       contents       { [] }
       variants_contents { {} }
     end
 
-    initialize_with { new(stock_location, contents) }
+    initialize_with { new(order, stock_location, contents) }
 
     after(:build) do |package, evaluator|
       evaluator.variants_contents.each do |variant, count|

--- a/core/lib/spree/testing_support/factories/stock_packer_factory.rb
+++ b/core/lib/spree/testing_support/factories/stock_packer_factory.rb
@@ -1,13 +1,15 @@
 require 'spree/testing_support/factories/stock_location_factory'
+require 'spree/testing_support/factories/order_factory'
 
 FactoryGirl.define do
   # must use build()
   factory :stock_packer, class: Spree::Stock::Packer do
     transient do
+      order { build(:order) }
       stock_location { build(:stock_location) }
       contents []
     end
 
-    initialize_with { new(stock_location, contents) }
+    initialize_with { new(order, stock_location, contents) }
   end
 end

--- a/core/spec/models/spree/stock/differentiator_spec.rb
+++ b/core/spec/models/spree/stock/differentiator_spec.rb
@@ -17,11 +17,11 @@ module Spree
       let(:order) { mock_model(Order, line_items: [line_item1, line_item2]) }
 
       let(:package1) do
-        Package.new(stock_location).tap { |p| p.add(inventory_unit1) }
+        Package.new(order, stock_location).tap { |p| p.add(inventory_unit1) }
       end
 
       let(:package2) do
-        Package.new(stock_location).tap { |p| p.add(inventory_unit2) }
+        Package.new(order, stock_location).tap { |p| p.add(inventory_unit2) }
       end
 
       let(:packages) { [package1, package2] }

--- a/core/spec/models/spree/stock/package_spec.rb
+++ b/core/spec/models/spree/stock/package_spec.rb
@@ -8,7 +8,7 @@ module Spree
       let(:order) { build(:order) }
       let(:line_item) { build(:line_item, order: order) }
 
-      subject { Package.new(stock_location) }
+      subject { Package.new(order, stock_location) }
 
       def build_inventory_unit
         build(:inventory_unit, variant: variant, line_item: line_item)
@@ -63,7 +63,7 @@ module Spree
                     ContentItem.new(build(:inventory_unit, variant: variant2)),
                     ContentItem.new(build(:inventory_unit, variant: variant3))]
 
-        package = Package.new(stock_location, contents)
+        package = Package.new(order, stock_location, contents)
         expect(package.shipping_methods).to match_array([method1, method2])
       end
       # Contains regression test for https://github.com/spree/spree/issues/2804
@@ -82,14 +82,14 @@ module Spree
                     ContentItem.new(build(:inventory_unit, variant: variant2)),
                     ContentItem.new(build(:inventory_unit, variant: variant3))]
 
-        package = Package.new(stock_location, contents)
+        package = Package.new(order, stock_location, contents)
         expect(package.shipping_methods).to match_array([method1])
       end
 
       it 'builds an empty list of shipping methods when no categories' do
         variant  = mock_model(Variant, shipping_category_id: nil)
         contents = [ContentItem.new(build(:inventory_unit, variant: variant))]
-        package  = Package.new(stock_location, contents)
+        package  = Package.new(order, stock_location, contents)
         expect(package.shipping_methods).to be_empty
       end
 
@@ -159,20 +159,8 @@ module Spree
       end
 
       describe "#order" do
-        let(:unit) { build_inventory_unit }
-        context "there is an inventory unit" do
-          before { subject.add unit }
-
-          it "returns an order" do
-            expect(subject.order).to be_a_kind_of Spree::Order
-            expect(subject.order).to eq order
-          end
-        end
-
-        context "there is no inventory unit" do
-          it "returns nil" do
-            expect(subject.order).to eq nil
-          end
+        it "returns the order the package has been initialized with" do
+          expect(subject.order).to eq(order)
         end
       end
     end

--- a/core/spec/models/spree/stock/packer_spec.rb
+++ b/core/spec/models/spree/stock/packer_spec.rb
@@ -3,10 +3,11 @@ require 'spec_helper'
 module Spree
   module Stock
     describe Packer, type: :model do
-      let!(:inventory_units) { Array.new(5) { build(:inventory_unit) } }
+      let(:order) { build(:order) }
+      let!(:inventory_units) { Array.new(5) { build(:inventory_unit, order: order) } }
       let(:stock_location) { create(:stock_location) }
 
-      subject { Packer.new(stock_location, inventory_units) }
+      subject { Packer.new(order, stock_location, inventory_units) }
 
       context 'packages' do
         it 'builds an array of packages' do
@@ -38,7 +39,7 @@ module Spree
 
         context "location doesn't have order items in stock" do
           let(:stock_location) { create(:stock_location, propagate_all_variants: false) }
-          let(:packer) { Packer.new(stock_location, inventory_units) }
+          let(:packer) { Packer.new(order, stock_location, inventory_units) }
 
           it "builds an empty package" do
             expect(packer.default_package).to be_empty
@@ -46,7 +47,7 @@ module Spree
         end
 
         context "none on hand and not backorderable" do
-          let(:packer) { Packer.new(stock_location, inventory_units) }
+          let(:packer) { Packer.new(order, stock_location, inventory_units) }
 
           before do
             stock_location.stock_items.update_all(backorderable: false)

--- a/core/spec/models/spree/stock/prioritizer_spec.rb
+++ b/core/spec/models/spree/stock/prioritizer_spec.rb
@@ -18,7 +18,7 @@ module Spree
       end
 
       def pack
-        package = Package.new(order)
+        package = Package.new(order, stock_location)
         yield(package) if block_given?
         package
       end

--- a/core/spec/models/spree/stock/splitter/backordered_spec.rb
+++ b/core/spec/models/spree/stock/splitter/backordered_spec.rb
@@ -5,13 +5,14 @@ module Spree
     module Splitter
       describe Backordered, type: :model do
         let(:variant) { build(:variant) }
+        let(:order) { build(:order) }
 
-        let(:packer) { build(:stock_packer) }
+        let(:packer) { build(:stock_packer, order: order) }
 
         subject { Backordered.new(packer) }
 
         it 'splits packages by status' do
-          package = Package.new(packer.stock_location)
+          package = Package.new(order, packer.stock_location)
           4.times { package.add build(:inventory_unit, variant: variant) }
           5.times { package.add build(:inventory_unit, variant: variant), :backordered }
 

--- a/core/spec/models/spree/stock/splitter/shipping_category_spec.rb
+++ b/core/spec/models/spree/stock/splitter/shipping_category_spec.rb
@@ -22,16 +22,16 @@ module Spree
         end
       end
 
-      let(:packer) { build(:stock_packer) }
+      let(:packer) { build(:stock_packer, order: order) }
 
       subject { described_class.new(packer) }
 
       it 'splits each package by shipping category' do
-        package1 = Package.new(packer.stock_location)
+        package1 = Package.new(order, packer.stock_location)
         4.times { package1.add inventory_unit1 }
         8.times { package1.add inventory_unit2 }
 
-        package2 = Package.new(packer.stock_location)
+        package2 = Package.new(order, packer.stock_location)
         6.times { package2.add inventory_unit1 }
         9.times { package2.add inventory_unit2, :backordered }
 

--- a/core/spec/models/spree/stock/splitter/weight_spec.rb
+++ b/core/spec/models/spree/stock/splitter/weight_spec.rb
@@ -4,20 +4,21 @@ module Spree
   module Stock
     module Splitter
       describe Weight, type: :model do
-        let(:packer) { build(:stock_packer) }
+        let(:order) { build(:order) }
+        let(:packer) { build(:stock_packer, order: order) }
         let(:variant) { build(:base_variant, weight: 100) }
 
         subject { Weight.new(packer) }
 
         it 'splits and keeps splitting until all packages are underweight' do
-          package = Package.new(packer.stock_location)
+          package = Package.new(order, packer.stock_location)
           4.times { package.add build(:inventory_unit, variant: variant) }
           packages = subject.split([package])
           expect(packages.size).to eq 4
         end
 
         it 'handles packages that can not be reduced' do
-          package = Package.new(packer.stock_location)
+          package = Package.new(order, packer.stock_location)
           allow(variant).to receive_messages(weight: 200)
           2.times { package.add build(:inventory_unit, variant: variant) }
           packages = subject.split([package])


### PR DESCRIPTION
This adds the order to the initialization signature of both the stock package and the stock packer. 

We know the order from the beginning of the stock coordination process, so it makes sense for it to be assigned to packages early on (and passed through split packages via the packer). 

This also adds a changelog entry. 